### PR TITLE
🔧 update Articles page title

### DIFF
--- a/themes/colinwilson/layouts/articles/list.html
+++ b/themes/colinwilson/layouts/articles/list.html
@@ -76,7 +76,7 @@
       routing: {
         router: instantsearch.routers.history({
           windowTitle({ query }) {
-            const queryTitle = query ? `Search Results for "${query}"` : 'Search';
+            const queryTitle = query ? `Search Results for "${query}"` : 'Articles';
             return queryTitle;
           },
 


### PR DESCRIPTION
[See Algolia `history` router for details](https://www.algolia.com/doc/api-reference/widgets/history-router/vue/#widget-param-windowtitle)