### PR TITLE
⚡ update search insights params

### DIFF
--- a/themes/colinwilson/layouts/articles/list.html
+++ b/themes/colinwilson/layouts/articles/list.html
@@ -69,7 +69,10 @@
     const insightsMiddleware = instantsearch.middlewares.createInsightsMiddleware({
       // Disable insightsClient in development
       //insightsClient: window.aa
-      insightsClient: {{- if .Site.IsServer }} null {{- else }} window.aa {{ end }}
+      insightsClient: {{- if .Site.IsServer }} null {{- else }} window.aa {{ end }},
+      insightsInitParams: {
+        useCookie: true,
+      }
     });
 
     // Group results by distinct attribute (year) function


### PR DESCRIPTION
Accommodate `search-insights v2.0.0`

With `search-insights >= v1.7.0 and < 2.0.0`, the insights client accepts `useCookie` and `userToken` parameters in the `init()` method. You can pass `useCookie: false` to prevent the usage of cookies to store an anonymous `userToken`. You can also pass a custom `userToken` while creating `insights` middleware, if you have one.

With `search-insights >= 2.0.0`, the default value of `useCookie` is `false`.

_Source: [https://www.algolia.com/doc/api-reference/widgets/insights/js/#widget-param-insightsinitparams](https://www.algolia.com/doc/api-reference/widgets/insights/js/#widget-param-insightsinitparams)_